### PR TITLE
Temporarily pin sphinx to versions < 7.2

### DIFF
--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<7.2
 sphinx-autobuild
 sphinx-design
 furo


### PR DESCRIPTION
Sphinx released version 7.2 recently, which is going through some growing pains and causing the GitHub PR checks to fail. This change temporarily pins sphinx to a known working version, so we can continue relying on the GitHub workers while all the sphinx bugs are being worked on.