### PR TITLE
Change Git repo link to brand-store-documentation

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -57,7 +57,7 @@ html_context = {
     'discourse': 'https://discourse.ubuntu.com',
 
     # Change to the GitHub info for your project
-    'github_url': 'https://github.com/canonical/starter-pack',
+    'github_url': 'https://github.com/canonical/brand-store-documentation',
 
     # Change to the branch for this version of the documentation
     'github_version': 'main',


### PR DESCRIPTION
This makes the "Edit this page on GitHub" and "Open a GitHub issue for this page" links work properly.