### PR TITLE
Improve PDF output

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -171,7 +171,11 @@ except:
 html_context = {**html_context, **template_values}
 
 latex_elements = {
+    'pointsize': '11pt',
     'preamble': r'''
+\usepackage{charter}
+\usepackage[defaultsans]{lato}
+\usepackage{inconsolata}
 \usepackage{tcolorbox}
 \definecolor{yellowgreen}{RGB}{154, 205, 50}
 \newenvironment{sphinxclassprompt}{\color{yellowgreen}}{}


### PR DESCRIPTION
The default colours for verbatim environments don't work well in the context of terminal output, so this change modifies the colours in the environments only for the terminal output (the colours work well for the few code listings in the documentation).

This change also modifies the fonts used in generating PDF output; unfortunately, we can't use the Ubuntu font, but we can at least use something that looks better than the default fonts.