### PR TITLE
Make table contents non-monospace, so they can be properly split in Latex

### DIFF
--- a/accounts.rst
+++ b/accounts.rst
@@ -18,7 +18,7 @@ Your store has been provisioned with the following data:
    :widths: 20 40 40
    :header-rows: 1
    :stub-columns: 1
-  
+
    * -
      - Base Store
      - Device view Store


### PR DESCRIPTION
This results in the email addresses being rendered as clickable links in both the PDF and HTML output, which does make it slightly harder to copy/paste them but at least they are being displayed in full and not cut off for long email addresses.