### PR TITLE
Add 'Controlling updates' section

### DIFF
--- a/configuration-values.rst
+++ b/configuration-values.rst
@@ -26,7 +26,18 @@ All stores (including your Device View Snap Store) always include the snapd snap
 
    If and when your organisation decides to create additional models, please ensure that you first request and use a new Device View Store for each new model. This can be done by opening a support ticket via your support portal. Using a single Device View Store per model allows for better isolation between your various models and ensures that potential changes to the inclusion rules for one model don't impact other models which may already be in use in production.
 
-Accounts and roles
+Controlling updates
+------------------
+
+One important consideration when deploying devices running Ubuntu Core is determining a method to control updates, in particular when those updates are for snaps from other publishers (e.g. Canonical). There are three general approaches to controlling and/or gating snap updates on Ubuntu Core:
+
+  * `Refresh Control https://ubuntu.com/core/docs/refresh-control`_ - this method provides a way to hold one or more snaps at specific revisions until newer revisions have first been validated by the brand. It can be enabled by opening a support ticket and requires a special gating snap which much be included in your images.
+  * `Validation Sets https://snapcraft.io/docs/validation-sets`_ - this method provides a similar mechnism to Refresh Control, however it's based on a special type of assertion called a validation-set. These assertions can be added at runtime to Ubuntu Core devices or seeded at image creation time by specififying one or more validation-set assertions in your model assertion. One advantage of validation sets vs. Refresh Control is that they allow a set of inter-related snaps to be validated as a set vs. validating snaps one by one.
+  * **Device Agent** - the final method that can be used to control updates involves use of a device agent, which is a dedicated service that takes full control of updates on an Ubuntu Core system by use of snapd's REST API. For more details, please see the `snapd-control interface https://snapcraft.io/docs/snapd-control-interface`
+
+**Note** - while Refresh Control is still supported, Validation Sets provide a more comprehensive approach to controlling updates, and in particular can guarantee that only specific combinations of snap revisions can be installed together.
+
+   Accounts and roles
 ------------------
 
 Ubuntu SSO accounts underpin developer interactions with the various Stores. To understand accounts and roles, please read:


### PR DESCRIPTION
This commit adds a new section which describes the various ways that customers can control updates on Ubuntu Core.

Note, the same sub-section has also been submitted as a suggestion to the current [Brand Store Onboarding for UC22](https://docs.google.com/document/d/11z7iKogO7FDouJBfYgh9hROK41xDeaPy0ruS2_flyL0/edit) template.